### PR TITLE
Update cupertinoLeftScroll.dart

### DIFF
--- a/lib/cupertinoLeftScroll.dart
+++ b/lib/cupertinoLeftScroll.dart
@@ -88,6 +88,7 @@ class CupertinoLeftScrollState extends State<CupertinoLeftScroll>
     );
 
     animationController = AnimationController(
+        value: 0,
         lowerBound: -maxDragDistance,
         upperBound: 0,
         vsync: this,


### PR DESCRIPTION
修复第一次用代码LeftScrollGlobalListener.instance.targetStatus(tag, key)=true 打开菜单时候失败的问题